### PR TITLE
fix: StackOverflow on Seqable w/ large queues

### DIFF
--- a/src/shams/priority_queue.clj
+++ b/src/shams/priority_queue.clj
@@ -10,13 +10,9 @@
 (defn- to-seq
   "Helper function to convert the priority->elements into a seq."
   [sorted-priorities priority->elements]
-  (loop [result-vector []
-         [priority & remaining-priorities] sorted-priorities]
-    (if priority
-      (recur
-        (concat result-vector (priority->elements priority))
-        remaining-priorities)
-      (seq result-vector))))
+  (->> sorted-priorities
+       (mapcat priority->elements)
+       (seq)))
 
 (defprotocol Bufferable
   (insert-into [elements element] "Inserts an element into the elements buffer.")

--- a/test/shams/priority_queue_test.clj
+++ b/test/shams/priority_queue_test.clj
@@ -119,7 +119,11 @@
         (is (= (pop pq) (.next pq)))
         (when (= variant :queue)
           (is (= (list 2 8 5 4 1 7 3 9 6) (seq pq)))
-          (is (= [2 8 5 4 1 7 3 9 6] (seq pq))))))))
+          (is (= [2 8 5 4 1 7 3 9 6] (seq pq))))))
+
+    (testing "large queues"
+      (let [pq (priority-queue identity :elements (range 50000))]
+        (is (seq pq))))))
 
 (deftest test-print-priority-queue
   (doseq [variant [:queue :set]]


### PR DESCRIPTION
Fixes an error where `to-seq` on large queues would cause a stack overflow.